### PR TITLE
[codex] Route trusted CI builds to Marvin runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  labels:
+    - self-hosted
+    - Linux
+    - X64
+    - marvin
+    - abrade-temp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,49 +1,112 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+  workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+  build-marvin:
+    name: Build (Marvin)
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: [self-hosted, Linux, X64, marvin, abrade-temp]
+    timeout-minutes: 90
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+      - name: Check out repository
+        uses: actions/checkout@v4
 
-    # Runs a set of commands using the runners shell
-    - name: Install build dependencies
-      run: |
-        sudo apt-get install cmake gcc-9 python3 python3-pip python3-setuptools
-        sudo python3 -m pip install --upgrade pip
-        sudo python3 -m pip install --upgrade conan conan-package-tools
-        
-    # Runs a set of commands using the runners shell
-    - name: Build
-      run: |
-        mkdir build && cd build
-        CC=gcc-9 CXX=g++-9 conan install .. --build missing -g cmake
-        CC=gcc-9 CXX=g++-9 cmake -DCMAKE_BUILD_TYPE=Release ..
-        make
-    
-    # Run tests
-    - name: Build
-      run: |
-        ./build/bin/abrade_test
-        ./build/bin/abrade --help
-      
-    - uses: actions/upload-artifact@v1
-      with:
-        name: abrade
-        path: ./build/bin/abrade
+      - name: Show runner context
+        run: |
+          echo "runner_name=${RUNNER_NAME}"
+          uname -a
+          cmake --version
+          python3 --version
+
+      - name: Install Conan 1
+        run: |
+          python3 -m pip install --user --break-system-packages "conan<2"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          "${HOME}/.local/bin/conan" --version
+
+      - name: Configure Conan profile
+        run: |
+          conan profile new default --detect --force
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+          conan profile show default
+
+      - name: Configure dependencies
+        run: |
+          mkdir -p build
+          cd build
+          conan install .. --build missing -g cmake
+
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-DCATCH_CONFIG_NO_POSIX_SIGNALS"
+
+      - name: Build
+        run: cmake --build build --parallel 4
+
+      - name: Test
+        run: |
+          ./build/bin/abrade_test
+          ./build/bin/abrade --help
+
+      - name: Upload abrade artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: abrade
+          path: build/bin/abrade
+          if-no-files-found: error
+
+  build-fork-pr:
+    name: Build (fork PR)
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake python3-pip
+          python3 -m pip install --user --break-system-packages "conan<2"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          "${HOME}/.local/bin/conan" --version
+
+      - name: Configure Conan profile
+        run: |
+          conan profile new default --detect --force
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+          conan profile show default
+
+      - name: Configure dependencies
+        run: |
+          mkdir -p build
+          cd build
+          conan install .. --build missing -g cmake
+
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-DCATCH_CONFIG_NO_POSIX_SIGNALS"
+
+      - name: Build
+        run: cmake --build build --parallel 4
+
+      - name: Test
+        run: |
+          ./build/bin/abrade_test
+          ./build/bin/abrade --help


### PR DESCRIPTION
## Summary

- route trusted CI runs to the temporary Marvin self-hosted runner via the `abrade-temp` label
- keep fork pull requests on GitHub-hosted runners so untrusted fork code does not execute on Marvin
- update legacy CI commands for the current runner image: Conan 1 install, explicit `libstdc++11` profile, CMake build, tests, and artifact upload
- add actionlint configuration for the repo-specific self-hosted runner labels
- remove the temporary branch-push trigger after proving the runner so PR branch pushes do not run duplicate CI

## Safety

Abrade is public. The Marvin job only runs for `push` to `master`, `workflow_dispatch`, and same-repository pull requests. Fork pull requests use the `ubuntu-latest` fallback job instead.

References JLospinoso/abrade#12.

## Follow-up configuration applied outside the diff

- Deleted stale external webhooks for CircleCI, Docker Hub, Docker Cloud, and Quay. The repo has no CircleCI config or Dockerfile, and the old CircleCI webhook was producing the failing external PR status.
- Protected `master` with required status check `Build (Marvin)`, strict branch currency, admin enforcement, pull-request-before-merge with zero required approvals, and force-push/deletion disabled.
- No `main` branch exists in this repository, so only `master` could be protected through branch protection.

## Validation

- `actionlint`
- `git diff --check`
- live Marvin runner probe inside `abrade-temp-runner`: Conan install, dependency configure, CMake configure/build, `abrade_test`, and `abrade --help`
- PR check run on refreshed head SHA `729a420`: `Build (Marvin)` passed on GitHub Actions; `Build (fork PR)` skipped as expected
