### PR TITLE
build: require C++23 toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
 
 function(abrade_target_defaults target)
-  target_compile_features(${target} PUBLIC cxx_std_17)
+  target_compile_features(${target} PUBLIC cxx_std_23)
   set_target_properties(${target} PROPERTIES
     CXX_EXTENSIONS OFF
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Abrade uses CMake presets and vcpkg manifest mode. Install:
 
 - CMake 3.24 or newer
 - Ninja
-- A C++17 compiler
+- A C++23 compiler
 - vcpkg
 
 Set `VCPKG_ROOT` to your vcpkg checkout before configuring:


### PR DESCRIPTION
## Summary

- raise Abrade's target compile feature from C++17 to C++23
- update README build requirements to match

## Why

Before adding new runtime/core code, verify that the local and Marvin toolchains can already build the project as C++23. This keeps the language-level decision separate from the larger scraper refactor.

Parent: #15

## Validation

- `cmake --preset ci -DVCPKG_TARGET_TRIPLET=arm64-osx`
- `cmake --build --preset ci --parallel`
- `ctest --preset ci`
- `./build/ci/abrade --help`
- `./build/ci/abrade example.com '/items/{1:3}' --test`
- `printf '/a\n/b\n' | ./build/ci/abrade example.com --stdin --test`
