### PR TITLE
feat: modernize scraper runtime core

### DIFF
--- a/Action.h
+++ b/Action.h
@@ -4,6 +4,7 @@
 #include <boost/regex.hpp>
 #include <boost/filesystem.hpp>
 #include "Exception.h"
+#include "HttpStatus.h"
 #include <iostream>
 #include <sstream>
 
@@ -17,7 +18,7 @@ struct HeadAction {
   }
 
   void process(int status_code, const std::string_view& candidate) {
-    if (status_code >= 200 && status_code < 300) { file << candidate << std::endl; }
+    if (is_success_status(status_code)) { file << candidate << std::endl; }
     if (is_verbose) std::cout << candidate << ": " << status_code << std::endl;
   }
 
@@ -44,7 +45,7 @@ struct GetAction {
       std::cout << "[ ] Response from " << candidate << ":\n" << contents_string << std::endl;
       write_out(contents_string, candidate);
     }
-    else if (status_code >= 200 && status_code < 300) { write_out(contents, candidate); }
+    else if (is_success_status(status_code)) { write_out(contents, candidate); }
   }
 
 private:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,14 +56,18 @@ add_library(abradelib STATIC
   Connection.h
   Controller.cpp
   Controller.h
+  Endpoint.h
   Exception.cpp
   Exception.h
   Generator.cpp
   Generator.h
+  HttpStatus.h
+  NetworkTimeout.h
   Options.cpp
   Options.h
   Query.h
   Scraper.h
+  ScraperRuntime.h
   Writer.h
 )
 abrade_target_defaults(abradelib)
@@ -97,10 +101,31 @@ if(BUILD_TESTING)
   include(Catch)
 
   add_executable(abrade_test
+    EndpointTest.cpp
     GeneratorTest.cpp
     OptionsTest.cpp
+    RuntimeTest.cpp
   )
   abrade_target_defaults(abrade_test)
   target_link_libraries(abrade_test PRIVATE abradelib Catch2::Catch2WithMain)
   catch_discover_tests(abrade_test)
+
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  find_program(ABRADE_OPENSSL_EXECUTABLE
+    NAMES openssl openssl.exe
+    HINTS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/tools/openssl"
+  )
+  set(ABRADE_SCRAPER_INTEGRATION_COMMAND
+    "${Python3_EXECUTABLE}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/scraper_integration.py"
+    "$<TARGET_FILE:abrade>"
+  )
+  if(ABRADE_OPENSSL_EXECUTABLE)
+    list(APPEND ABRADE_SCRAPER_INTEGRATION_COMMAND "--openssl" "${ABRADE_OPENSSL_EXECUTABLE}")
+  endif()
+  add_test(
+    NAME ScraperIntegration
+    COMMAND ${ABRADE_SCRAPER_INTEGRATION_COMMAND}
+  )
+  set_tests_properties(ScraperIntegration PROPERTIES TIMEOUT 90)
 endif()

--- a/Connection.h
+++ b/Connection.h
@@ -6,8 +6,11 @@
 #include <string>
 #include <array>
 #include "Exception.h"
+#include "Endpoint.h"
+#include "NetworkTimeout.h"
 #include <utility>
 #include <memory>
+#include <vector>
 
 template <typename Stream>
 struct Connection {
@@ -32,12 +35,9 @@ private:
 
 struct PlaintextConnection {
   PlaintextConnection(const std::string& host_name, bool sensitive_teardown, boost::asio::io_context& ios)
-    : sensitive_teardown{sensitive_teardown} {
-    boost::system::error_code ec;
-    boost::asio::ip::tcp::resolver resolver{ios};
-    lookup_result = resolver.resolve(host_name, "http", ec);
-    if (ec) throw AbradeException{"resolve host", ec};
-  }
+    : sensitive_teardown{sensitive_teardown},
+      endpoint{parse_host_endpoint(host_name, "80", 80)},
+      ios{ios} { }
 
   auto connect(
     boost::asio::ip::tcp::socket& sock,
@@ -53,31 +53,41 @@ struct PlaintextConnection {
     },
       sock);
 
-    boost::system::error_code ec;
-    async_connect(result->get(), lookup_result, yield[ec]);
-    if (ec) throw AbradeException{"tcp connect", ec};
+    boost::asio::ip::tcp::resolver resolver{ios};
+    const auto lookup_result = await_resolver_with_timeout<boost::asio::ip::tcp::resolver::results_type>(
+      resolver,
+      "resolve host",
+      yield,
+      [this, &resolver](auto token) { return resolver.async_resolve(endpoint.host, endpoint.service, token); }
+    );
+    await_stream_with_timeout(result->get(), "tcp connect", yield, [&result, &lookup_result](auto token) {
+      boost::asio::async_connect(result->get(), lookup_result, token);
+    });
 
     return std::move(result);
   }
 
 private:
   bool sensitive_teardown;
-  boost::asio::ip::tcp::resolver::results_type lookup_result;
+  HostEndpoint endpoint;
+  boost::asio::io_context& ios;
 };
 
 struct TlsConnection {
   TlsConnection(const std::string& host_name, bool is_verify, bool sensitive_teardown, boost::asio::io_context& ios)
-    : sensitive_teardown{sensitive_teardown}, context{boost::asio::ssl::context::sslv23} {
+    : sensitive_teardown{sensitive_teardown},
+      endpoint{parse_host_endpoint(host_name, "443", 443)},
+      context{boost::asio::ssl::context::tls_client},
+      ios{ios} {
     boost::system::error_code ec;
-    context.set_default_verify_paths(ec);
-    if (ec) throw AbradeException{"ssl default verify path", ec};
+    if (is_verify) {
+      context.set_default_verify_paths(ec);
+      if (ec) throw AbradeException{"ssl default verify path", ec};
+    }
     const auto verify_mode = is_verify
                                ? boost::asio::ssl::verify_peer | boost::asio::ssl::verify_fail_if_no_peer_cert
                                : boost::asio::ssl::verify_none;
     context.set_verify_mode(verify_mode);
-    boost::asio::ip::tcp::resolver resolver{ios};
-    lookup_result = resolver.resolve(host_name, "https", ec);
-    if (sensitive_teardown && ec) throw AbradeException{"resolve host", ec};
   }
 
   auto connect(
@@ -91,35 +101,38 @@ struct TlsConnection {
     },
       sock, context);
 
-    boost::system::error_code ec;
-    async_connect(sock, lookup_result, yield[ec]);
-    if (ec) throw AbradeException{"ssl connect", ec};
+    boost::asio::ip::tcp::resolver resolver{ios};
+    const auto lookup_result = await_resolver_with_timeout<boost::asio::ip::tcp::resolver::results_type>(
+      resolver,
+      "resolve host",
+      yield,
+      [this, &resolver](auto token) { return resolver.async_resolve(endpoint.host, endpoint.service, token); }
+    );
+    await_stream_with_timeout(sock, "ssl connect", yield, [&sock, &lookup_result](auto token) {
+      boost::asio::async_connect(sock, lookup_result, token);
+    });
 
-    result->get().async_handshake(boost::asio::ssl::stream_base::client, yield[ec]);
-    if (ec) throw AbradeException{"ssl handshake", ec};
+    await_stream_with_timeout(result->get(), "ssl handshake", yield, [&result](auto token) {
+      result->get().async_handshake(boost::asio::ssl::stream_base::client, token);
+    });
 
     return std::move(result);
   }
 
 private:
   const bool sensitive_teardown;
-  boost::asio::ip::tcp::resolver::results_type lookup_result;
+  HostEndpoint endpoint;
   boost::asio::ssl::context context;
+  boost::asio::io_context& ios;
 };
 
 struct ProxiedConnection {
   ProxiedConnection(const std::string& proxy, const std::string& host_name, bool sensitive_teardown,
                     boost::asio::io_context& ios)
-    : sensitive_teardown{sensitive_teardown}, host_name{host_name} {
-    boost::system::error_code ec;
-    const auto colon_pos = proxy.find(':');
-    if (std::string::npos == colon_pos) throw AbradeException("Proxy does not contain colon (:).");
-    boost::asio::ip::tcp::resolver resolver{ios};
-    const auto proxy_host = proxy.substr(0, colon_pos);
-    const auto proxy_port = proxy.substr(colon_pos + 1, proxy.size());
-    proxy_lookup = resolver.resolve(proxy_host, proxy_port, ec);
-    if (ec) throw AbradeException{"resolve proxy", ec};
-  }
+    : sensitive_teardown{sensitive_teardown},
+      endpoint{parse_host_endpoint(host_name, "80", 80)},
+      proxy_endpoint{parse_host_endpoint(proxy, "1080", 1080)},
+      ios{ios} { }
 
   auto connect(
     boost::asio::ip::tcp::socket& sock,
@@ -136,17 +149,28 @@ struct ProxiedConnection {
     },
       sock);
 
-    boost::system::error_code ec;
-    async_connect(result->get(), proxy_lookup, yield[ec]);
-    if (ec) throw AbradeException{"proxy connect ", ec};
+    boost::asio::ip::tcp::resolver resolver{ios};
+    const auto proxy_lookup = await_resolver_with_timeout<boost::asio::ip::tcp::resolver::results_type>(
+      resolver,
+      "resolve proxy",
+      yield,
+      [this, &resolver](auto token) {
+        return resolver.async_resolve(proxy_endpoint.host, proxy_endpoint.service, token);
+      }
+    );
+    await_stream_with_timeout(result->get(), "proxy connect", yield, [&result, &proxy_lookup](auto token) {
+      boost::asio::async_connect(result->get(), proxy_lookup, token);
+    });
 
     static const std::array<unsigned char, 3> auth_request{5, 1, 0};
-    async_write(result->get(), boost::asio::buffer(auth_request.data(), auth_request.size()), yield[ec]);
-    if (ec) throw AbradeException{"proxy write auth", ec};
+    await_stream_with_timeout(result->get(), "proxy write auth", yield, [&result](auto token) {
+      boost::asio::async_write(result->get(), boost::asio::buffer(auth_request.data(), auth_request.size()), token);
+    });
 
     std::array<char, 2> auth_response;
-    async_read(result->get(), boost::asio::buffer(auth_response.data(), auth_response.size()), yield[ec]);
-    if (ec) throw AbradeException{"proxy read auth", ec};
+    await_stream_with_timeout(result->get(), "proxy read auth", yield, [&result, &auth_response](auto token) {
+      boost::asio::async_read(result->get(), boost::asio::buffer(auth_response.data(), auth_response.size()), token);
+    });
 
     if (auth_response[0] != 5) {
       std::string err_msg{"SOCKS version "};
@@ -166,21 +190,23 @@ struct ProxiedConnection {
       0x01, // Connect
       0x00, // Reserved
       0x03, // Domain
-      static_cast<unsigned char>(host_name.size())
+      static_cast<unsigned char>(endpoint.host.size())
     };
-    for (auto& name_byte : host_name) { connect_request.emplace_back(name_byte); }
-    connect_request.emplace_back(0); // high port byte
-    connect_request.emplace_back(80); // low port byte
-    async_write(result->get(), boost::asio::buffer(connect_request.data(), connect_request.size()), yield[ec]);
-    if (ec) throw AbradeException{"proxy connection", ec};
+    for (auto& name_byte : endpoint.host) { connect_request.emplace_back(name_byte); }
+    connect_request.emplace_back(static_cast<unsigned char>((endpoint.port >> 8) & 0xFF));
+    connect_request.emplace_back(static_cast<unsigned char>(endpoint.port & 0xFF));
+    await_stream_with_timeout(result->get(), "proxy connection", yield, [&result, &connect_request](auto token) {
+      boost::asio::async_write(result->get(), boost::asio::buffer(connect_request.data(), connect_request.size()), token);
+    });
 
     std::array<char, 10> connect_response;
-    async_read(result->get(), boost::asio::buffer(connect_response.data(), connect_response.size()), yield[ec]);
-    if (ec) throw AbradeException{"proxy read", ec};
+    await_stream_with_timeout(result->get(), "proxy read", yield, [&result, &connect_response](auto token) {
+      boost::asio::async_read(result->get(), boost::asio::buffer(connect_response.data(), connect_response.size()), token);
+    });
 
-    if (auth_response[1] != 0) {
+    if (connect_response[1] != 0) {
       std::string err_msg{"SOCKS connection failed:"};
-      err_msg.append(std::to_string(auth_response[1]));
+      err_msg.append(std::to_string(connect_response[1]));
       throw AbradeException{std::move(err_msg)};
     }
 
@@ -189,31 +215,29 @@ struct ProxiedConnection {
 
 private:
   const bool sensitive_teardown;
-  const std::string host_name;
-  boost::asio::ip::tcp::resolver::results_type proxy_lookup;
+  HostEndpoint endpoint;
+  HostEndpoint proxy_endpoint;
+  boost::asio::io_context& ios;
 };
 
 struct ProxiedTlsConnection {
   ProxiedTlsConnection(const std::string& proxy, const std::string& host_name, bool is_verify,
                        bool sensitive_teardown,
                        boost::asio::io_context& ios)
-    : sensitive_teardown{sensitive_teardown}, host_name{host_name}, context {
-        boost::asio::ssl::context::sslv23_client
-      } {
+    : sensitive_teardown{sensitive_teardown},
+      endpoint{parse_host_endpoint(host_name, "443", 443)},
+      proxy_endpoint{parse_host_endpoint(proxy, "1080", 1080)},
+      context{boost::asio::ssl::context::tls_client},
+      ios{ios} {
     boost::system::error_code ec;
-    context.set_default_verify_paths(ec);
-    if (ec) throw AbradeException{"default CA path set", ec};
+    if (is_verify) {
+      context.set_default_verify_paths(ec);
+      if (ec) throw AbradeException{"default CA path set", ec};
+    }
     const auto verify_mode = is_verify
                                ? boost::asio::ssl::verify_peer | boost::asio::ssl::verify_fail_if_no_peer_cert
                                : boost::asio::ssl::verify_none;
     context.set_verify_mode(verify_mode);
-    const auto colon_pos = proxy.find(':');
-    if (std::string::npos == colon_pos) throw AbradeException("Proxy does not contain colon (:).");
-    boost::asio::ip::tcp::resolver resolver{ios};
-    const auto proxy_host = proxy.substr(0, colon_pos);
-    const auto proxy_port = proxy.substr(colon_pos + 1, proxy.size());
-    proxy_lookup = resolver.resolve(proxy_host, proxy_port, ec);
-    if (ec) throw AbradeException{"resolve proxy", ec};
   }
 
   auto connect(
@@ -228,17 +252,28 @@ struct ProxiedTlsConnection {
     },
       sock, context);
 
-    boost::system::error_code ec;
-    async_connect(sock, proxy_lookup, yield[ec]);
-    if (ec) throw AbradeException{"proxy connect ", ec};
+    boost::asio::ip::tcp::resolver resolver{ios};
+    const auto proxy_lookup = await_resolver_with_timeout<boost::asio::ip::tcp::resolver::results_type>(
+      resolver,
+      "resolve proxy",
+      yield,
+      [this, &resolver](auto token) {
+        return resolver.async_resolve(proxy_endpoint.host, proxy_endpoint.service, token);
+      }
+    );
+    await_stream_with_timeout(sock, "proxy connect", yield, [&sock, &proxy_lookup](auto token) {
+      boost::asio::async_connect(sock, proxy_lookup, token);
+    });
 
     static const std::array<unsigned char, 3> auth_request{5, 1, 0};
-    async_write(sock, boost::asio::buffer(auth_request.data(), auth_request.size()), yield[ec]);
-    if (ec) throw AbradeException{"proxy write auth", ec};
+    await_stream_with_timeout(sock, "proxy write auth", yield, [&sock](auto token) {
+      boost::asio::async_write(sock, boost::asio::buffer(auth_request.data(), auth_request.size()), token);
+    });
 
     std::array<char, 2> auth_response;
-    async_read(sock, boost::asio::buffer(auth_response.data(), auth_response.size()), yield[ec]);
-    if (ec) throw AbradeException{"proxy read auth", ec};
+    await_stream_with_timeout(sock, "proxy read auth", yield, [&sock, &auth_response](auto token) {
+      boost::asio::async_read(sock, boost::asio::buffer(auth_response.data(), auth_response.size()), token);
+    });
 
     if (auth_response[0] != 5) {
       std::string err_msg{"SOCKS version "};
@@ -258,33 +293,37 @@ struct ProxiedTlsConnection {
       0x01, // Connect
       0x00, // Reserved
       0x03, // Domain
-      static_cast<unsigned char>(host_name.size())
+      static_cast<unsigned char>(endpoint.host.size())
     };
-    for (auto& name_byte : host_name) { connect_request.emplace_back(name_byte); }
-    connect_request.emplace_back(0x01); // high port byte
-    connect_request.emplace_back(0xBB); // low port byte
-    async_write(sock, boost::asio::buffer(connect_request.data(), connect_request.size()), yield[ec]);
-    if (ec) throw AbradeException{"proxy connection", ec};
+    for (auto& name_byte : endpoint.host) { connect_request.emplace_back(name_byte); }
+    connect_request.emplace_back(static_cast<unsigned char>((endpoint.port >> 8) & 0xFF));
+    connect_request.emplace_back(static_cast<unsigned char>(endpoint.port & 0xFF));
+    await_stream_with_timeout(sock, "proxy connection", yield, [&sock, &connect_request](auto token) {
+      boost::asio::async_write(sock, boost::asio::buffer(connect_request.data(), connect_request.size()), token);
+    });
 
     std::array<char, 10> connect_response;
-    async_read(sock, boost::asio::buffer(connect_response.data(), connect_response.size()), yield[ec]);
-    if (ec) throw AbradeException{"proxy read", ec};
+    await_stream_with_timeout(sock, "proxy read", yield, [&sock, &connect_response](auto token) {
+      boost::asio::async_read(sock, boost::asio::buffer(connect_response.data(), connect_response.size()), token);
+    });
 
-    if (auth_response[1] != 0) {
+    if (connect_response[1] != 0) {
       std::string err_msg{"SOCKS connection failed:"};
-      err_msg.append(std::to_string(auth_response[1]));
+      err_msg.append(std::to_string(connect_response[1]));
       throw AbradeException{std::move(err_msg)};
     }
 
-    result->get().async_handshake(boost::asio::ssl::stream_base::client, yield[ec]);
-    if (ec) throw AbradeException{"proxied ssl handshake", ec};
+    await_stream_with_timeout(result->get(), "proxied ssl handshake", yield, [&result](auto token) {
+      result->get().async_handshake(boost::asio::ssl::stream_base::client, token);
+    });
 
     return std::move(result);
   }
 
 private:
   const bool sensitive_teardown;
-  const std::string& host_name;
-  boost::asio::ip::tcp::resolver::results_type proxy_lookup;
+  HostEndpoint endpoint;
+  HostEndpoint proxy_endpoint;
   boost::asio::ssl::context context;
+  boost::asio::io_context& ios;
 };

--- a/Endpoint.h
+++ b/Endpoint.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <charconv>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+struct HostEndpoint {
+  std::string authority;
+  std::string host;
+  std::string service;
+  std::uint16_t port;
+};
+
+inline std::uint16_t parse_tcp_port(std::string_view text) {
+  if (text.empty()) {
+    throw std::runtime_error{"Host port is empty."};
+  }
+  unsigned int parsed{};
+  const auto* begin = text.data();
+  const auto* end = text.data() + text.size();
+  const auto [ptr, ec] = std::from_chars(begin, end, parsed);
+  if (ec != std::errc{} || ptr != end || parsed == 0 || parsed > 65535) {
+    throw std::runtime_error{"Host port is invalid."};
+  }
+  return static_cast<std::uint16_t>(parsed);
+}
+
+inline HostEndpoint parse_host_endpoint(std::string_view authority,
+                                        std::string_view default_service,
+                                        std::uint16_t default_port) {
+  if (authority.empty()) {
+    throw std::runtime_error{"Host is empty."};
+  }
+
+  std::string_view host = authority;
+  std::string_view service = default_service;
+  auto port = default_port;
+
+  if (authority.front() == '[') {
+    const auto close = authority.find(']');
+    if (close == std::string_view::npos) {
+      throw std::runtime_error{"Bracketed IPv6 host is missing closing bracket."};
+    }
+    host = authority.substr(1, close - 1);
+    const auto rest = authority.substr(close + 1);
+    if (!rest.empty()) {
+      if (rest.front() != ':') {
+        throw std::runtime_error{"Bracketed IPv6 host has invalid suffix."};
+      }
+      service = rest.substr(1);
+      port = parse_tcp_port(service);
+    }
+  } else {
+    const auto first_colon = authority.find(':');
+    const auto last_colon = authority.rfind(':');
+    if (first_colon != std::string_view::npos && first_colon == last_colon) {
+      host = authority.substr(0, first_colon);
+      service = authority.substr(first_colon + 1);
+      port = parse_tcp_port(service);
+    }
+  }
+
+  if (host.empty()) {
+    throw std::runtime_error{"Host is empty."};
+  }
+
+  return HostEndpoint{
+    std::string{authority},
+    std::string{host},
+    std::string{service},
+    port
+  };
+}

--- a/EndpointTest.cpp
+++ b/EndpointTest.cpp
@@ -1,0 +1,49 @@
+#include <catch2/catch_test_macros.hpp>
+#include "Endpoint.h"
+
+TEST_CASE("HostEndpoint") {
+  SECTION("uses default service and port for plain host") {
+    const auto endpoint = parse_host_endpoint("example.com", "443", 443);
+
+    REQUIRE(endpoint.authority == "example.com");
+    REQUIRE(endpoint.host == "example.com");
+    REQUIRE(endpoint.service == "443");
+    REQUIRE(endpoint.port == 443);
+  }
+
+  SECTION("parses host and explicit port") {
+    const auto endpoint = parse_host_endpoint("example.com:8443", "443", 443);
+
+    REQUIRE(endpoint.authority == "example.com:8443");
+    REQUIRE(endpoint.host == "example.com");
+    REQUIRE(endpoint.service == "8443");
+    REQUIRE(endpoint.port == 8443);
+  }
+
+  SECTION("keeps unbracketed IPv6 as a host without parsing a port") {
+    const auto endpoint = parse_host_endpoint("::1", "80", 80);
+
+    REQUIRE(endpoint.host == "::1");
+    REQUIRE(endpoint.service == "80");
+    REQUIRE(endpoint.port == 80);
+  }
+
+  SECTION("parses bracketed IPv6 with explicit port") {
+    const auto endpoint = parse_host_endpoint("[::1]:8080", "80", 80);
+
+    REQUIRE(endpoint.authority == "[::1]:8080");
+    REQUIRE(endpoint.host == "::1");
+    REQUIRE(endpoint.service == "8080");
+    REQUIRE(endpoint.port == 8080);
+  }
+
+  SECTION("rejects invalid authorities") {
+    REQUIRE_THROWS(parse_host_endpoint("", "80", 80));
+    REQUIRE_THROWS(parse_host_endpoint(":80", "80", 80));
+    REQUIRE_THROWS(parse_host_endpoint("example.com:", "80", 80));
+    REQUIRE_THROWS(parse_host_endpoint("example.com:0", "80", 80));
+    REQUIRE_THROWS(parse_host_endpoint("example.com:65536", "80", 80));
+    REQUIRE_THROWS(parse_host_endpoint("[::1", "80", 80));
+    REQUIRE_THROWS(parse_host_endpoint("[::1]extra", "80", 80));
+  }
+}

--- a/HttpStatus.h
+++ b/HttpStatus.h
@@ -1,0 +1,5 @@
+#pragma once
+
+inline bool is_success_status(int status_code) noexcept {
+  return status_code >= 200 && status_code < 300;
+}

--- a/NetworkTimeout.h
+++ b/NetworkTimeout.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <boost/asio/spawn.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/beast/core.hpp>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <limits>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include "Exception.h"
+
+inline std::chrono::milliseconds network_operation_timeout() {
+  static const auto timeout = [] {
+    constexpr auto default_timeout = std::chrono::milliseconds{30000};
+    const auto* raw_timeout = std::getenv("ABRADE_NETWORK_TIMEOUT_MS");
+    if (raw_timeout == nullptr || raw_timeout[0] == '\0') {
+      return default_timeout;
+    }
+
+    char* end{};
+    const auto parsed = std::strtoull(raw_timeout, &end, 10);
+    if (*end != '\0' || parsed == 0 || parsed > static_cast<unsigned long long>(std::numeric_limits<int>::max())) {
+      return default_timeout;
+    }
+
+    return std::chrono::milliseconds{parsed};
+  }();
+
+  return timeout;
+}
+
+template <typename Executor, typename Cancel, typename Start>
+void await_void_with_timeout(Executor executor,
+                             Cancel&& cancel,
+                             std::string_view action,
+                             const boost::asio::yield_context& yield,
+                             Start&& start) {
+  auto active = std::make_shared<std::atomic_bool>(true);
+  auto timed_out = std::make_shared<std::atomic_bool>(false);
+  auto cancel_operation = std::make_shared<std::decay_t<Cancel>>(std::forward<Cancel>(cancel));
+  boost::asio::steady_timer timer{executor};
+  timer.expires_after(network_operation_timeout());
+  timer.async_wait([active, timed_out, cancel_operation](const boost::system::error_code& ec) {
+    if (!ec && active->exchange(false)) {
+      timed_out->store(true);
+      (*cancel_operation)();
+    }
+  });
+
+  boost::system::error_code ec;
+  std::forward<Start>(start)(yield[ec]);
+  active->store(false);
+  timer.cancel();
+
+  if (timed_out->load()) {
+    throw AbradeException{std::string{action} + " timeout"};
+  }
+  if (ec) {
+    throw AbradeException{std::string{action}, ec};
+  }
+}
+
+template <typename Result, typename Executor, typename Cancel, typename Start>
+Result await_result_with_timeout(Executor executor,
+                                 Cancel&& cancel,
+                                 std::string_view action,
+                                 const boost::asio::yield_context& yield,
+                                 Start&& start) {
+  auto active = std::make_shared<std::atomic_bool>(true);
+  auto timed_out = std::make_shared<std::atomic_bool>(false);
+  auto cancel_operation = std::make_shared<std::decay_t<Cancel>>(std::forward<Cancel>(cancel));
+  boost::asio::steady_timer timer{executor};
+  timer.expires_after(network_operation_timeout());
+  timer.async_wait([active, timed_out, cancel_operation](const boost::system::error_code& ec) {
+    if (!ec && active->exchange(false)) {
+      timed_out->store(true);
+      (*cancel_operation)();
+    }
+  });
+
+  boost::system::error_code ec;
+  auto result = std::forward<Start>(start)(yield[ec]);
+  active->store(false);
+  timer.cancel();
+
+  if (timed_out->load()) {
+    throw AbradeException{std::string{action} + " timeout"};
+  }
+  if (ec) {
+    throw AbradeException{std::string{action}, ec};
+  }
+
+  return result;
+}
+
+template <typename Stream, typename Start>
+void await_stream_with_timeout(Stream& stream,
+                               std::string_view action,
+                               const boost::asio::yield_context& yield,
+                               Start&& start) {
+  auto& lowest_layer = boost::beast::get_lowest_layer(stream);
+  await_void_with_timeout(
+    lowest_layer.get_executor(),
+    [&lowest_layer] {
+      boost::system::error_code ignored;
+      lowest_layer.cancel(ignored);
+    },
+    action,
+    yield,
+    std::forward<Start>(start)
+  );
+}
+
+template <typename Result, typename Resolver, typename Start>
+Result await_resolver_with_timeout(Resolver& resolver,
+                                   std::string_view action,
+                                   const boost::asio::yield_context& yield,
+                                   Start&& start) {
+  return await_result_with_timeout<Result>(
+    resolver.get_executor(),
+    [&resolver] { resolver.cancel(); },
+    action,
+    yield,
+    std::forward<Start>(start)
+  );
+}

--- a/Options.cpp
+++ b/Options.cpp
@@ -13,7 +13,7 @@ Options::Options(int argc, const char** argv)
     test{}, telescoping{} {
   options_description description("Usage: abrade host pattern");
   description.add_options()
-    ("host", value<string>(&host), "host name (eg example.com)")
+    ("host", value<string>(&host), "host name, optionally host:port (eg example.com)")
     ("pattern", value<string>(&pattern)->default_value("/"), "format of URL (eg ?mynum={1:5}&myhex=0x{hhhh}). See documentation for formatting of patterns.")
     ("agent", value<string>(&user_agent)->default_value("Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0"), "User-agent string (default: Firefox 47)")
     ("out", value<string>(&output_path)->default_value(""), "output path. dir if contents enabled. (default: HOSTNAME)")

--- a/Query.h
+++ b/Query.h
@@ -8,6 +8,8 @@
 #include "Action.h"
 #include "Exception.h"
 #include "Candidate.h"
+#include "HttpStatus.h"
+#include "NetworkTimeout.h"
 
 //TODO: PostQuery
 
@@ -17,15 +19,15 @@ struct GetQuery {
 
   template <typename Stream>
   void execute(Stream& stream, const std::string_view& description, const boost::asio::yield_context& yield) {
-    boost::system::error_code ec;
     boost::beast::flat_buffer buffer;
     boost::beast::http::response<boost::beast::http::dynamic_body> response;
-    boost::beast::http::async_read(stream, buffer, response, yield[ec]);
-    if (ec) throw AbradeException{"get query", ec};
+    await_stream_with_timeout(stream, "get query", yield, [&stream, &buffer, &response](auto token) {
+      boost::beast::http::async_read(stream, buffer, response, token);
+    });
     action.process(response.result_int(), response, description);
 
     const auto status_code = response.result_int();
-    if (print_found && (status_code >= 200 && status_code < 300)) {
+    if (print_found && is_success_status(status_code)) {
       std::cout << "[+] Status of " << description << ": " << status_code << std::endl;
     }
     else if (verbose) { std::cout << "[-] Status of " << description << ": " << status_code << std::endl; }
@@ -45,16 +47,16 @@ struct HeadQuery {
 
   template <typename Stream>
   void execute(Stream& stream, const std::string_view& description, const boost::asio::yield_context& yield) {
-    boost::system::error_code ec;
     boost::beast::flat_buffer buffer;
     boost::beast::http::response_parser<boost::beast::http::empty_body> parser;
-    boost::beast::http::async_read_header(stream, buffer, parser, yield[ec]);
-    if (ec) throw AbradeException{"head query", ec};
+    await_stream_with_timeout(stream, "head query", yield, [&stream, &buffer, &parser](auto token) {
+      boost::beast::http::async_read_header(stream, buffer, parser, token);
+    });
     const auto& response = parser.release();
     action.process(response.result_int(), description);
 
     const auto status_code = response.result_int();
-    if (print_found && (status_code >= 200 && status_code < 300)) {
+    if (print_found && is_success_status(status_code)) {
       std::cout << "[+] Status of " << description << ": " << status_code << std::endl;
     }
     else if (verbose) { std::cout << "[-] Status of " << description << ": " << status_code << std::endl; }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Check out the [blog post](https://jlospinoso.github.io/cpp/developing/software/2
 ```
 > abrade -h
 Usage: abrade host pattern:
-  --host arg                            host name (eg example.com)
+  --host arg                            host name, optionally host:port (eg
+                                        example.com)
   --pattern arg (=/)                    format of URL (eg ?mynum={1:5}&myhex=0x
                                         {hhhh}). See documentation for
                                         formatting of patterns.
@@ -64,6 +65,9 @@ You must omit the `pattern` positional argument to pipe from stdin.
 You can also use the `--screen` option to detect error landing pages that
 still return 200 responses. Such responses get *screened* out and will not
 get written to disk during a `--content` scrape.
+
+Network resolve, connect, TLS handshake, proxy negotiation, request write, and
+response read operations time out after 30 seconds.
 
 
 ## [Linux ELF](https://s3.amazonaws.com/net.lospi.abrade/0.2.0/abrade)
@@ -120,6 +124,8 @@ ctest --preset ci
 ./build/ci/abrade example.com '/items/{1:3}' --test
 printf '/a\n/b\n' | ./build/ci/abrade example.com --stdin --test
 ```
+
+`ctest --preset ci` includes loopback integration tests for the scraper runtime.
 
 On Windows PowerShell, set `VCPKG_ROOT` with `$env:VCPKG_ROOT = "C:\path\to\vcpkg"`
 and use `.\build\ci\abrade.exe` for the smoke commands.

--- a/RuntimeTest.cpp
+++ b/RuntimeTest.cpp
@@ -1,0 +1,23 @@
+#include <catch2/catch_test_macros.hpp>
+#include "HttpStatus.h"
+#include "ScraperRuntime.h"
+
+TEST_CASE("HttpStatus") {
+  SECTION("classifies successful responses") {
+    REQUIRE_FALSE(is_success_status(199));
+    REQUIRE(is_success_status(200));
+    REQUIRE(is_success_status(204));
+    REQUIRE(is_success_status(299));
+    REQUIRE_FALSE(is_success_status(300));
+  }
+}
+
+TEST_CASE("ScraperRuntime") {
+  SECTION("creates candidates from generated URIs") {
+    const auto candidate = make_candidate("/items/1");
+
+    REQUIRE(candidate.uri == "/items/1");
+    REQUIRE(candidate.headers.empty());
+    REQUIRE(candidate.contents.empty());
+  }
+}

--- a/Scraper.h
+++ b/Scraper.h
@@ -10,13 +10,13 @@
 #include <fstream>
 #include "Controller.h"
 #include "Candidate.h"
+#include "ScraperRuntime.h"
 
-template <typename Generator, typename Query, typename Connection, typename RequestWriter>
+template <typename Generator, typename Query, typename Connection, typename RequestWriter, typename ErrorLog>
 struct Scraper {
-  Scraper(Query&& query, Connection&& connection, RequestWriter&& writer, Controller& controller,
-          boost::asio::io_context& ios, bool is_verbose, const std::string& error_path)
-    : is_verbose{is_verbose},
-      error_path{error_path},
+  Scraper(Query&& query, Connection&& connection, RequestWriter&& writer, ErrorLog&& error_log, Controller& controller,
+          boost::asio::io_context& ios)
+    : error_log{std::forward<ErrorLog>(error_log)},
       controller{controller},
       ios{ios},
       query {std::forward<Query>(query)},
@@ -44,18 +44,10 @@ private:
           while (const auto uri = generator.next()) { 
             if (active_coroutines < controller.recommended_coroutines()) { spawn_coroutine(generator); }
             // TODO: Need to generate URI, headers, and contents. How to integrate patterns?
-            Candidate candidate{
-              *uri,
-              {}, // Headers
-              {}  // Contents
-            };
+            auto candidate = make_candidate(*uri);
             try { coroutine(yield, candidate); }
             catch (const std::exception& e) {
-              std::ofstream file;
-              file.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-              file.open(error_path, std::ofstream::out | std::ofstream::app);
-              file << *uri << ": " << e.what() << std::endl;
-              if (is_verbose) std::cerr << "[-] Exception: " << e.what() << std::endl;
+              error_log.record(*uri, e);
             }
             controller.register_completion(active_coroutines);
             if (active_coroutines > controller.recommended_coroutines()) return;
@@ -71,8 +63,7 @@ private:
     query.execute(instance->get(), candidate.description(), yield);
   }
 
-  bool is_verbose;
-  std::string error_path;
+  ErrorLog error_log;
   Controller& controller;
   boost::asio::io_context& ios;
   Query query;

--- a/ScraperRuntime.h
+++ b/ScraperRuntime.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include "Candidate.h"
+
+inline Candidate make_candidate(std::string uri) {
+  return Candidate{
+    std::move(uri),
+    {},
+    {}
+  };
+}
+
+struct FileErrorLog {
+  FileErrorLog(std::string path, bool verbose)
+    : path{std::move(path)},
+      verbose{verbose} { }
+
+  void record(std::string_view uri, const std::exception& error) const {
+    std::ofstream file;
+    file.exceptions(std::ios_base::failbit | std::ios_base::badbit);
+    file.open(path, std::ofstream::out | std::ofstream::app);
+    file << uri << ": " << error.what() << std::endl;
+    if (verbose) {
+      std::cerr << "[-] Exception: " << error.what() << std::endl;
+    }
+  }
+
+private:
+  std::string path;
+  bool verbose;
+};

--- a/Writer.h
+++ b/Writer.h
@@ -4,6 +4,7 @@
 #include <string>
 #include "Exception.h"
 #include "Candidate.h"
+#include "NetworkTimeout.h"
 
 using RequestType = boost::beast::http::request<boost::beast::http::string_body>;
 
@@ -28,9 +29,9 @@ struct RequestWriter {
     //TODO: Content, headers.
     request.prepare_payload();
     if (is_verbose) std::cout << "[ ] Payload for " << candidate.uri << ": " << request;
-    boost::system::error_code ec;
-    boost::beast::http::async_write(stream, request, yield[ec]);
-    if (ec) throw AbradeException{"make request", ec};
+    await_stream_with_timeout(stream, "make request", yield, [&stream, &request](auto token) {
+      boost::beast::http::async_write(stream, request, token);
+    });
   }
 
 private:

--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 #include "Action.h"
 #include "Writer.h"
 #include "Controller.h"
+#include "ScraperRuntime.h"
 
 using namespace std;
 
@@ -16,10 +17,13 @@ namespace {
   void run_scraper(Generator&& generator, Query&& query, Connection&& connection,
                    Controller& controller, RequestWriter& writer, boost::asio::io_context& ios,
                    const Options& options) {
-    Scraper<Generator, Query, Connection, RequestWriter> scraper{
-      std::forward<Query>(query), std::forward<Connection>(connection), std::forward<RequestWriter>(writer), controller,
-      ios,
-      options.is_verbose(), options.get_error_path()
+    Scraper<Generator, Query, Connection, RequestWriter, FileErrorLog> scraper{
+      std::forward<Query>(query),
+      std::forward<Connection>(connection),
+      std::forward<RequestWriter>(writer),
+      FileErrorLog{options.get_error_path(), options.is_verbose()},
+      controller,
+      ios
     };
     scraper.run(std::forward<Generator>(generator));
   }

--- a/tests/scraper_integration.py
+++ b/tests/scraper_integration.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import http.server
+import os
+import select
+import shutil
+import socket
+import socketserver
+import ssl
+import subprocess
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+
+OPENSSL_CONFIG = """[req]
+distinguished_name = dn
+x509_extensions = v3_req
+prompt = no
+
+[dn]
+CN = 127.0.0.1
+
+[v3_req]
+subjectAltName = IP:127.0.0.1,DNS:localhost
+"""
+
+
+def resolve_openssl(explicit_path: str | None) -> str:
+  if explicit_path:
+    return explicit_path
+  from_environment = os.environ.get("ABRADE_TEST_OPENSSL")
+  if from_environment:
+    return from_environment
+  from_path = shutil.which("openssl")
+  if from_path:
+    return from_path
+  raise AssertionError("openssl executable is required for TLS integration tests")
+
+
+def generate_test_certificate(work_dir: Path, openssl: str) -> tuple[Path, Path]:
+  cert_file = work_dir / "server.crt"
+  key_file = work_dir / "server.key"
+  config_file = work_dir / "openssl.cnf"
+  config_file.write_text(OPENSSL_CONFIG, encoding="utf-8")
+  command = [
+    openssl,
+    "req",
+    "-x509",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-keyout",
+    str(key_file),
+    "-out",
+    str(cert_file),
+    "-days",
+    "1",
+    "-config",
+    str(config_file),
+    "-sha256",
+  ]
+  result = subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=20, check=False)
+  if result.returncode != 0:
+    raise AssertionError(
+      f"openssl failed to generate TLS fixture certificate\ncommand={command}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+  return cert_file, key_file
+
+
+class FixtureHandler(http.server.BaseHTTPRequestHandler):
+  def do_HEAD(self) -> None:
+    if self.path in {"/found", "/secure"}:
+      self.send_response(200)
+      self.send_header("Content-Length", "0")
+      self.end_headers()
+    else:
+      self.send_response(404)
+      self.send_header("Content-Length", "0")
+      self.end_headers()
+
+  def do_GET(self) -> None:
+    if self.path == "/disconnect":
+      with contextlib.suppress(OSError):
+        self.connection.shutdown(socket.SHUT_RDWR)
+      self.connection.close()
+      return
+    if self.path == "/slow":
+      time.sleep(1)
+
+    routes = {
+      "/found": (200, b"FOUND BODY\n"),
+      "/screen": (200, b"SCREENED BODY\n"),
+      "/slow": (200, b"SLOW BODY\n"),
+      "/secure": (200, b"SECURE BODY\n"),
+    }
+    status, body = routes.get(self.path, (404, b"missing\n"))
+    self.send_response(status)
+    self.send_header("Content-Type", "text/plain")
+    self.send_header("Content-Length", str(len(body)))
+    self.end_headers()
+    self.wfile.write(body)
+
+  def log_message(self, fmt: str, *args: object) -> None:
+    return
+
+
+class FixtureServer:
+  def __init__(self, tls: bool, work_dir: Path, openssl: str | None = None) -> None:
+    self.tls = tls
+    self.work_dir = work_dir
+    self.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), FixtureHandler)
+    if tls:
+      cert_file, key_file = generate_test_certificate(work_dir, resolve_openssl(openssl))
+      context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+      context.load_cert_chain(cert_file, key_file)
+      self.server.socket = context.wrap_socket(self.server.socket, server_side=True)
+    self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+  @property
+  def authority(self) -> str:
+    host, port = self.server.server_address[:2]
+    return f"{host}:{port}"
+
+  def __enter__(self) -> "FixtureServer":
+    self.thread.start()
+    return self
+
+  def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+    self.server.shutdown()
+    self.server.server_close()
+    self.thread.join(timeout=5)
+
+
+def recv_exact(sock: socket.socket, size: int) -> bytes:
+  chunks: list[bytes] = []
+  remaining = size
+  while remaining:
+    chunk = sock.recv(remaining)
+    if not chunk:
+      raise ConnectionError("unexpected EOF")
+    chunks.append(chunk)
+    remaining -= len(chunk)
+  return b"".join(chunks)
+
+
+class SocksProxyHandler(socketserver.BaseRequestHandler):
+  def handle(self) -> None:
+    request: socket.socket = self.request
+    version, method_count = recv_exact(request, 2)
+    methods = recv_exact(request, method_count)
+    if version != 5 or 0 not in methods:
+      request.sendall(b"\x05\xff")
+      return
+    request.sendall(b"\x05\x00")
+
+    version, command, _reserved, address_type = recv_exact(request, 4)
+    if version != 5 or command != 1:
+      request.sendall(b"\x05\x07\x00\x01\x00\x00\x00\x00\x00\x00")
+      return
+    if address_type == 1:
+      host = socket.inet_ntoa(recv_exact(request, 4))
+    elif address_type == 3:
+      length = recv_exact(request, 1)[0]
+      host = recv_exact(request, length).decode("ascii")
+    else:
+      request.sendall(b"\x05\x08\x00\x01\x00\x00\x00\x00\x00\x00")
+      return
+    port = int.from_bytes(recv_exact(request, 2), "big")
+
+    with socket.create_connection((host, port), timeout=5) as upstream:
+      request.sendall(b"\x05\x00\x00\x01\x7f\x00\x00\x01\x00\x00")
+      while True:
+        readable, _, _ = select.select([request, upstream], [], [], 5)
+        if not readable:
+          return
+        for source in readable:
+          target = upstream if source is request else request
+          data = source.recv(65536)
+          if not data:
+            return
+          target.sendall(data)
+
+
+class SocksProxyServer:
+  def __init__(self) -> None:
+    class ThreadingTcpServer(socketserver.ThreadingTCPServer):
+      allow_reuse_address = True
+
+    self.server = ThreadingTcpServer(("127.0.0.1", 0), SocksProxyHandler)
+    self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+  @property
+  def authority(self) -> str:
+    host, port = self.server.server_address[:2]
+    return f"{host}:{port}"
+
+  def __enter__(self) -> "SocksProxyServer":
+    self.thread.start()
+    return self
+
+  def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+    self.server.shutdown()
+    self.server.server_close()
+    self.thread.join(timeout=5)
+
+
+def run_abrade(
+  exe: Path,
+  cwd: Path,
+  args: list[str],
+  stdin: str | None = None,
+  env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+  command = [str(exe), *args, "--init", "1", "--sint", "1000"]
+  environment = os.environ.copy()
+  if env:
+    environment.update(env)
+  result = subprocess.run(
+    command,
+    cwd=cwd,
+    env=environment,
+    input=stdin,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    timeout=30,
+    check=False,
+  )
+  if result.returncode != 0:
+    raise AssertionError(
+      f"abrade returned {result.returncode}\ncommand={command}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+  return result
+
+
+def read_text(path: Path) -> str:
+  return path.read_text(encoding="utf-8")
+
+
+def require(condition: bool, message: str) -> None:
+  if not condition:
+    raise AssertionError(message)
+
+
+def test_head_found(exe: Path, tmp: Path, server: FixtureServer) -> None:
+  out = tmp / "head-found.txt"
+  err = tmp / "head-found.err"
+  run_abrade(exe, tmp, [server.authority, "/found", "--out", str(out), "--err", str(err)])
+  require(read_text(out).splitlines() == ["/found"], "HEAD should record only found resources")
+  require(not err.exists() or read_text(err) == "", "HEAD found path should not write errors")
+
+
+def test_stdin_head_filters_missing(exe: Path, tmp: Path, server: FixtureServer) -> None:
+  out = tmp / "stdin-found.txt"
+  err = tmp / "stdin-found.err"
+  run_abrade(
+    exe,
+    tmp,
+    [server.authority, "--stdin", "--out", str(out), "--err", str(err)],
+    stdin="/found\n/missing\n",
+  )
+  require(read_text(out).splitlines() == ["/found"], "stdin HEAD should omit 404 resources")
+  require(not err.exists() or read_text(err) == "", "stdin HEAD should not write errors for 404 responses")
+
+
+def test_get_contents(exe: Path, tmp: Path, server: FixtureServer) -> None:
+  out_dir = tmp / "contents"
+  err = tmp / "contents.err"
+  run_abrade(exe, tmp, [server.authority, "/found", "--contents", "--out", str(out_dir), "--err", str(err)])
+  output = out_dir / "_found"
+  require(output.exists(), "GET contents should write a file for 2xx responses")
+  require("FOUND BODY" in read_text(output), "GET contents file should include response body")
+
+
+def test_screen_filters_contents(exe: Path, tmp: Path, server: FixtureServer) -> None:
+  out_dir = tmp / "screened"
+  err = tmp / "screened.err"
+  run_abrade(
+    exe,
+    tmp,
+    [server.authority, "/screen", "--contents", "--screen", "SCREENED", "--out", str(out_dir), "--err", str(err)],
+  )
+  require(not (out_dir / "_screen").exists(), "screened 2xx contents should not be written")
+
+
+def test_error_log_records_transport_failure(exe: Path, tmp: Path, server: FixtureServer) -> None:
+  out_dir = tmp / "disconnect"
+  err = tmp / "disconnect.err"
+  run_abrade(exe, tmp, [server.authority, "/disconnect", "--contents", "--out", str(out_dir), "--err", str(err)])
+  require(err.exists(), "transport failure should create an error log")
+  err_text = read_text(err)
+  require("/disconnect" in err_text, "transport failure should identify the candidate URI")
+
+
+def test_timeout_records_error(exe: Path, tmp: Path, server: FixtureServer) -> None:
+  out_dir = tmp / "timeout"
+  err = tmp / "timeout.err"
+  run_abrade(
+    exe,
+    tmp,
+    [server.authority, "/slow", "--contents", "--out", str(out_dir), "--err", str(err)],
+    env={"ABRADE_NETWORK_TIMEOUT_MS": "100"},
+  )
+  require(err.exists(), "timeout should create an error log")
+  err_text = read_text(err)
+  require("/slow" in err_text, "timeout should identify the candidate URI")
+  require("timeout" in err_text, "timeout should identify the timeout failure")
+
+
+def test_socks_proxy_head(exe: Path, tmp: Path, server: FixtureServer) -> None:
+  out = tmp / "proxy-head.txt"
+  err = tmp / "proxy-head.err"
+  with SocksProxyServer() as proxy:
+    run_abrade(
+      exe,
+      tmp,
+      [server.authority, "/found", "--proxy", proxy.authority, "--out", str(out), "--err", str(err)],
+    )
+  require(read_text(out).splitlines() == ["/found"], "SOCKS proxy should forward HEAD requests")
+  require(not err.exists() or read_text(err) == "", "SOCKS proxy HEAD should not write errors")
+
+
+def test_tls_no_verify(exe: Path, tmp: Path, server: FixtureServer) -> None:
+  out = tmp / "tls-head.txt"
+  err = tmp / "tls-head.err"
+  run_abrade(exe, tmp, [server.authority, "/secure", "--tls", "--out", str(out), "--err", str(err)])
+  require(read_text(out).splitlines() == ["/secure"], "TLS without verification should accept test cert")
+
+
+def test_tls_verify_rejects_self_signed(exe: Path, tmp: Path, server: FixtureServer) -> None:
+  out = tmp / "tls-verify.txt"
+  err = tmp / "tls-verify.err"
+  result = run_abrade(exe, tmp, [server.authority, "/secure", "--tls", "--verify", "--out", str(out), "--err", str(err)])
+  if err.exists():
+    require("/secure" in read_text(err), "TLS verify failure should identify the candidate URI")
+  else:
+    combined_output = result.stdout + result.stderr
+    require("ssl" in combined_output.lower(), "TLS verify failure should report an SSL error")
+  require(not out.exists() or read_text(out) == "", "TLS verify failure should not record the resource as found")
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser()
+  parser.add_argument("abrade", type=Path)
+  parser.add_argument("--openssl")
+  args = parser.parse_args()
+
+  exe = args.abrade.resolve()
+  if os.name == "nt" and exe.suffix.lower() != ".exe":
+    exe = exe.with_suffix(".exe")
+  require(exe.exists(), f"abrade executable does not exist: {exe}")
+
+  with tempfile.TemporaryDirectory(prefix="abrade-integration-") as tmp_raw:
+    tmp = Path(tmp_raw)
+    with FixtureServer(tls=False, work_dir=tmp) as server:
+      test_head_found(exe, tmp, server)
+      test_stdin_head_filters_missing(exe, tmp, server)
+      test_get_contents(exe, tmp, server)
+      test_screen_filters_contents(exe, tmp, server)
+      test_error_log_records_transport_failure(exe, tmp, server)
+      test_timeout_records_error(exe, tmp, server)
+      test_socks_proxy_head(exe, tmp, server)
+
+    tls_dir = tmp / "tls"
+    tls_dir.mkdir()
+    with FixtureServer(tls=True, work_dir=tls_dir, openssl=args.openssl) as server:
+      test_tls_no_verify(exe, tmp, server)
+      test_tls_verify_rejects_self_signed(exe, tmp, server)
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## Summary

- add deterministic loopback scraper integration coverage through CTest for HEAD, stdin, contents, screen filtering, transport errors, timeout errors, SOCKS5 proxying, and TLS verify/no-verify behavior
- introduce tested runtime seams for endpoint parsing, status classification, candidate creation, and injectable scrape-error logging
- modernize network internals on the C++23 baseline with explicit `tls_client`, host:port/proxy port parsing, SOCKS response validation, and 30-second operation timeouts for resolve/connect/proxy/TLS/write/read
- document host:port support, scraper integration tests, and network timeout behavior without changing the public CLI flags

## Validation

- `cmake --preset ci -DVCPKG_TARGET_TRIPLET=arm64-osx`
- `cmake --build --preset ci --parallel`
- `ctest --preset ci --output-on-failure`
- `./build/ci/abrade --help`
- `./build/ci/abrade example.com '/items/{1:3}' --test`
- `printf '/a\n/b\n' | ./build/ci/abrade example.com --stdin --test`
- `actionlint`

Closes #15
Closes #16
Closes #17
Closes #18
Closes #19
Refs #20
Refs #12
