### PR TITLE
feat: add tag-based release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,237 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to build, for example v0.3.0
+        required: true
+        default: v0.3.0
+      publish_release:
+        description: Publish a GitHub Release for an existing tag
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ inputs.tag || '' }}
+  cancel-in-progress: false
+
+env:
+  VCPKG_COMMIT: 38a77589121bd7ec6487927b79c191a75d4ebdd6
+  RELEASE_TAG: ${{ github.event_name == 'push' && github.ref_name || inputs.tag }}
+
+jobs:
+  build-release:
+    name: Build release (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Read release metadata
+        id: metadata
+        shell: bash
+        run: |
+          python tools/release/release.py metadata \
+            --tag "${RELEASE_TAG}" \
+            --source-dir "${GITHUB_WORKSPACE}" \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Install hosted dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${RUNNER_OS}" == "Linux" ]]; then
+            sudo apt-get update
+            sudo apt-get install -y build-essential cmake curl git ninja-build perl pkg-config tar unzip zip
+          elif [[ "${RUNNER_OS}" == "macOS" ]]; then
+            brew install ninja
+          fi
+
+      - name: Prepare vcpkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${RUNNER_OS}-${RUNNER_ARCH}" in
+            Linux-X64) triplet="x64-linux" ;;
+            Linux-ARM64) triplet="arm64-linux" ;;
+            macOS-X64) triplet="x64-osx" ;;
+            macOS-ARM64) triplet="arm64-osx" ;;
+            Windows-X64) triplet="x64-windows-static" ;;
+            *) echo "Unsupported runner ${RUNNER_OS}-${RUNNER_ARCH}" >&2; exit 1 ;;
+          esac
+
+          git clone --filter=blob:none https://github.com/microsoft/vcpkg.git "${RUNNER_TEMP}/vcpkg"
+          git -C "${RUNNER_TEMP}/vcpkg" checkout "${VCPKG_COMMIT}"
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            vcpkg_root="$(cygpath -m "${RUNNER_TEMP}/vcpkg")"
+            vcpkg_cache="$(cygpath -m "${RUNNER_TEMP}/vcpkg-cache")"
+            "${RUNNER_TEMP}/vcpkg/bootstrap-vcpkg.bat" -disableMetrics
+          else
+            vcpkg_root="${RUNNER_TEMP}/vcpkg"
+            vcpkg_cache="${RUNNER_TEMP}/vcpkg-cache"
+            "${RUNNER_TEMP}/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
+          fi
+          mkdir -p "${RUNNER_TEMP}/vcpkg-cache"
+          {
+            echo "VCPKG_ROOT=${vcpkg_root}"
+            echo "VCPKG_BINARY_SOURCES=clear;files,${vcpkg_cache},readwrite"
+            echo "VCPKG_TARGET_TRIPLET=${triplet}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Cache vcpkg binary packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/vcpkg-cache
+          key: release-vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('vcpkg.json') }}-${{ env.VCPKG_COMMIT }}
+          restore-keys: |
+            release-vcpkg-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Configure
+        if: ${{ runner.os != 'Windows' }}
+        shell: bash
+        run: cmake --preset release -DVCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}"
+
+      - name: Configure
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vs = & $vswhere -latest -property installationPath
+          $vcvars = Join-Path $vs "VC\Auxiliary\Build\vcvars64.bat"
+          cmd /c "`"$vcvars`" && cmake --preset release -DVCPKG_TARGET_TRIPLET=$env:VCPKG_TARGET_TRIPLET"
+
+      - name: Build
+        if: ${{ runner.os != 'Windows' }}
+        shell: bash
+        run: cmake --build --preset release --parallel
+
+      - name: Build
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vs = & $vswhere -latest -property installationPath
+          $vcvars = Join-Path $vs "VC\Auxiliary\Build\vcvars64.bat"
+          cmd /c "`"$vcvars`" && cmake --build --preset release --parallel"
+
+      - name: Test
+        if: ${{ runner.os != 'Windows' }}
+        shell: bash
+        run: ctest --preset release
+
+      - name: Test
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vs = & $vswhere -latest -property installationPath
+          $vcvars = Join-Path $vs "VC\Auxiliary\Build\vcvars64.bat"
+          cmd /c "`"$vcvars`" && ctest --preset release"
+
+      - name: Smoke CLI
+        if: ${{ runner.os != 'Windows' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./build/release/abrade --help
+          ./build/release/abrade example.com '/items/{1:3}' --test
+          printf '/a\n/b\n' | ./build/release/abrade example.com --stdin --test
+
+      - name: Smoke CLI
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          .\build\release\abrade.exe --help
+          .\build\release\abrade.exe example.com '/items/{1:3}' --test
+          "/a`n/b`n" | .\build\release\abrade.exe example.com --stdin --test
+
+      - name: Install
+        shell: bash
+        run: |
+          cmake --install build/release --prefix "release-stage/${{ steps.metadata.outputs.artifact_base }}"
+
+      - name: Package
+        shell: bash
+        run: |
+          python tools/release/release.py package \
+            --stage "release-stage/${{ steps.metadata.outputs.artifact_base }}" \
+            --dist dist \
+            --archive-name "${{ steps.metadata.outputs.archive_name }}"
+
+      - name: Upload release archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ steps.metadata.outputs.platform }}
+          path: dist/${{ steps.metadata.outputs.archive_name }}
+          if-no-files-found: error
+
+  release:
+    name: Publish release assets
+    needs: build-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Download release archives
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          path: dist
+          merge-multiple: true
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          python tools/release/release.py checksums --dist dist --output dist/SHA256SUMS
+          cat dist/SHA256SUMS
+
+      - name: Upload release rehearsal assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-${{ env.RELEASE_TAG }}
+          path: dist/*
+          if-no-files-found: error
+
+      - name: Publish GitHub Release
+        if: ${{ github.event_name == 'push' || inputs.publish_release }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh release create "${RELEASE_TAG}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "Abrade ${RELEASE_TAG}" \
+            --generate-notes \
+            --verify-tag

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,8 @@ CMakeUserPresets.json
 build/*
 build-nix/*
 build-win/*
+dist/*
+release-stage/*
 abrade.dir/*
 abrade_test.dir/*
 abradelib.dir/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-project(abrade VERSION 0.2.0 LANGUAGES CXX)
+project(abrade VERSION 0.3.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 include(CTest)
@@ -94,6 +94,7 @@ abrade_target_defaults(abrade)
 target_link_libraries(abrade PRIVATE abradelib)
 
 install(TARGETS abrade RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+install(FILES LICENSE README.md DESTINATION "${CMAKE_INSTALL_DOCDIR}")
 
 if(BUILD_TESTING)
   find_package(Catch2 3 REQUIRED)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,38 @@ _Abrade is a coroutine-based web scraper suitable for querying the existence (a 
 
 Check out the [blog post](https://jlospinoso.github.io/cpp/developing/software/2017/09/15/abrade-web-scraper.html) at [http://lospi.net](http://lospi.net) for usage and examples.
 
+# Installing Abrade
+
+Current Abrade binaries are published on the
+[GitHub Releases](https://github.com/JLospinoso/abrade/releases) page.
+
+Download the archive for your platform, verify it with `SHA256SUMS`, and place
+the executable on your `PATH`.
+
+Linux:
+
+```
+sha256sum -c SHA256SUMS --ignore-missing
+tar -xzf abrade-VERSION-linux-x64.tar.gz
+```
+
+macOS:
+
+```
+shasum -a 256 -c SHA256SUMS
+tar -xzf abrade-VERSION-macos-arm64.tar.gz
+```
+
+macOS users may need to allow the downloaded executable in System Settings
+because release artifacts are not notarized.
+
+Windows PowerShell:
+
+```
+Get-FileHash .\abrade-VERSION-windows-x64.zip -Algorithm SHA256
+Expand-Archive .\abrade-VERSION-windows-x64.zip
+```
+
 ```
 > abrade -h
 Usage: abrade host pattern:
@@ -69,30 +101,15 @@ get written to disk during a `--content` scrape.
 Network resolve, connect, TLS handshake, proxy negotiation, request write, and
 response read operations time out after 30 seconds.
 
+# Historical Binaries
 
-## [Linux ELF](https://s3.amazonaws.com/net.lospi.abrade/0.2.0/abrade)
+Older pre-GitHub-Releases binaries were distributed through S3. These links are
+kept for historical reference only; use GitHub Releases for current downloads.
 
-* 2,310 KB. SHA-256=89df60eebcf1c8f224fed98b89ee403b45022c86181a12e84cba8abc5d56ca07
-* https://s3.amazonaws.com/net.lospi.abrade/0.2.0/abrade
-
-## [Windows EXE](https://s3.amazonaws.com/net.lospi.abrade/0.2.0/abrade.exe)
-
-* 1,187 KB. SHA-256=b574aa1d8e37f9f0a867ed4d890d5b3d152388f0f4e3d9c9c4223d7804d1be4b
-* This is an Authenticode signed binary (Issued to: Joshua Alfred Lospinoso)
-* https://s3.amazonaws.com/net.lospi.abrade/0.2.0/abrade.exe
-
-# v0.1
-
-## [Linux ELF](https://s3.amazonaws.com/net.lospi.abrade/0.1.0/abrade)
-
-* 2,243 KB. SHA-256=1b8adf0fe8b7db252c4f84398bf5980f0a0c57a7592cd529ac6558b57407f238
-* https://s3.amazonaws.com/net.lospi.abrade/0.1.0/abrade
-
-## [Windows EXE](https://s3.amazonaws.com/net.lospi.abrade/0.1.0/abrade.exe)
-
-* 1,181 KB. SHA-256=f98ca3a68fbdcc7dde3f7db868b24d8a0b328d3c05732aa1d81b5a70b0531f31
-* This is an Authenticode signed binary (Issued to: Joshua Alfred Lospinoso)
-* https://s3.amazonaws.com/net.lospi.abrade/0.1.0/abrade.exe
+- v0.2.0 Linux ELF: SHA-256 `89df60eebcf1c8f224fed98b89ee403b45022c86181a12e84cba8abc5d56ca07`
+- v0.2.0 Windows EXE: SHA-256 `b574aa1d8e37f9f0a867ed4d890d5b3d152388f0f4e3d9c9c4223d7804d1be4b`
+- v0.1.0 Linux ELF: SHA-256 `1b8adf0fe8b7db252c4f84398bf5980f0a0c57a7592cd529ac6558b57407f238`
+- v0.1.0 Windows EXE: SHA-256 `f98ca3a68fbdcc7dde3f7db868b24d8a0b328d3c05732aa1d81b5a70b0531f31`
 
 # Building Abrade
 
@@ -129,3 +146,9 @@ printf '/a\n/b\n' | ./build/ci/abrade example.com --stdin --test
 
 On Windows PowerShell, set `VCPKG_ROOT` with `$env:VCPKG_ROOT = "C:\path\to\vcpkg"`
 and use `.\build\ci\abrade.exe` for the smoke commands.
+
+# Releasing Abrade
+
+Maintainer release instructions live in [docs/RELEASING.md](docs/RELEASING.md).
+Release tags use `vMAJOR.MINOR.PATCH` and must match the CMake project version
+without the leading `v`.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,92 @@
+# Releasing Abrade
+
+Abrade releases are GitHub-native. A semver tag such as `v0.3.0` publishes a
+GitHub Release with Linux, macOS, and Windows archives plus `SHA256SUMS`.
+
+## Version Contract
+
+- `CMakeLists.txt` is the source of the project version.
+- Release tags must match `vMAJOR.MINOR.PATCH`.
+- The tag version must equal the CMake project version without the leading `v`.
+- Example: `project(abrade VERSION 0.3.0 LANGUAGES CXX)` releases from tag
+  `v0.3.0`.
+
+## Rehearse A Release
+
+Use the `Release` workflow manually before pushing a real release tag:
+
+1. Open GitHub Actions.
+2. Run the `Release` workflow on the target branch.
+3. Set `tag` to the intended release tag, such as `v0.3.0`.
+4. Leave `publish_release` unchecked.
+5. Confirm the workflow produces `release-assets-TAG`.
+6. Download the artifact and verify `SHA256SUMS`.
+
+The rehearsal uses hosted Linux, macOS, and Windows runners. Ordinary PRs remain
+on the bounded Marvin/fork-safe CI path.
+
+## Publish A Release
+
+After the rehearsal passes and `master` is green:
+
+```
+git switch master
+git pull --ff-only origin master
+git tag -a v0.3.0 -m "Abrade v0.3.0"
+git push origin v0.3.0
+```
+
+The tag push starts the `Release` workflow. The workflow:
+
+- validates the tag against the CMake version;
+- configures, builds, tests, and smoke-tests each hosted platform;
+- stages the install tree with `cmake --install`;
+- creates platform archives;
+- generates `SHA256SUMS`;
+- publishes the GitHub Release with all release assets.
+
+## Verify Assets
+
+Linux:
+
+```
+sha256sum -c SHA256SUMS --ignore-missing
+```
+
+macOS:
+
+```
+shasum -a 256 -c SHA256SUMS
+```
+
+Windows PowerShell:
+
+```
+Get-FileHash .\abrade-0.3.0-windows-x64.zip -Algorithm SHA256
+```
+
+Compare the digest to the matching line in `SHA256SUMS`.
+
+## Bad Release Rollback
+
+If a release tag publishes bad assets:
+
+1. Delete the GitHub Release from the Releases page or with `gh release delete`.
+2. Delete the remote tag only after confirming no users should consume it:
+
+   ```
+   git push origin :refs/tags/v0.3.0
+   ```
+
+3. Delete the local tag:
+
+   ```
+   git tag -d v0.3.0
+   ```
+
+4. Fix the issue on a PR.
+5. Rehearse again.
+6. Publish a new patch tag.
+
+Prefer a new patch version over rewriting a published tag after users may have
+downloaded artifacts.

--- a/tools/release/release.py
+++ b/tools/release/release.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import tarfile
+import zipfile
+from pathlib import Path
+
+
+TAG_PATTERN = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
+PROJECT_VERSION_PATTERN = re.compile(r"project\s*\(\s*abrade\s+VERSION\s+([0-9]+\.[0-9]+\.[0-9]+)\s+", re.I)
+
+
+def project_version(source_dir: Path) -> str:
+  cmake = (source_dir / "CMakeLists.txt").read_text(encoding="utf-8")
+  match = PROJECT_VERSION_PATTERN.search(cmake)
+  if not match:
+    raise SystemExit("Could not find Abrade project version in CMakeLists.txt")
+  return match.group(1)
+
+
+def tag_version(tag: str) -> str:
+  match = TAG_PATTERN.fullmatch(tag)
+  if not match:
+    raise SystemExit(f"Release tag must match vMAJOR.MINOR.PATCH: {tag}")
+  return match.group("version")
+
+
+def platform_id() -> str:
+  runner_os = os.environ.get("RUNNER_OS", os.uname().sysname if hasattr(os, "uname") else "")
+  runner_arch = os.environ.get("RUNNER_ARCH", os.uname().machine if hasattr(os, "uname") else "")
+  normalized = {
+    ("Linux", "X64"): "linux-x64",
+    ("Linux", "ARM64"): "linux-arm64",
+    ("macOS", "X64"): "macos-x64",
+    ("macOS", "ARM64"): "macos-arm64",
+    ("Windows", "X64"): "windows-x64",
+    ("Windows", "ARM64"): "windows-arm64",
+  }.get((runner_os, runner_arch))
+  if normalized:
+    return normalized
+
+  os_name = runner_os.lower().replace("darwin", "macos")
+  arch = runner_arch.lower().replace("amd64", "x64").replace("x86_64", "x64").replace("aarch64", "arm64")
+  return f"{os_name}-{arch}"
+
+
+def write_github_outputs(path: Path, values: dict[str, str]) -> None:
+  with path.open("a", encoding="utf-8") as output:
+    for key, value in values.items():
+      output.write(f"{key}={value}\n")
+
+
+def metadata(args: argparse.Namespace) -> None:
+  source_dir = args.source_dir.resolve()
+  version = tag_version(args.tag)
+  cmake_version = project_version(source_dir)
+  if version != cmake_version:
+    raise SystemExit(f"Release tag {args.tag} does not match CMake project version {cmake_version}")
+
+  platform = platform_id()
+  archive_ext = "zip" if platform.startswith("windows-") else "tar.gz"
+  artifact_base = f"abrade-{version}-{platform}"
+  values = {
+    "version": version,
+    "tag": args.tag,
+    "platform": platform,
+    "artifact_base": artifact_base,
+    "archive_name": f"{artifact_base}.{archive_ext}",
+  }
+  if args.github_output:
+    write_github_outputs(args.github_output, values)
+  for key, value in values.items():
+    print(f"{key}={value}")
+
+
+def add_zip_tree(archive: zipfile.ZipFile, root: Path) -> None:
+  for path in sorted(root.rglob("*")):
+    if path.is_file():
+      archive.write(path, path.relative_to(root.parent).as_posix())
+
+
+def package(args: argparse.Namespace) -> None:
+  stage = args.stage.resolve()
+  dist = args.dist.resolve()
+  dist.mkdir(parents=True, exist_ok=True)
+  if not stage.is_dir():
+    raise SystemExit(f"Stage directory does not exist: {stage}")
+
+  if args.archive_name.endswith(".zip"):
+    archive_path = dist / args.archive_name
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+      add_zip_tree(archive, stage)
+  elif args.archive_name.endswith(".tar.gz"):
+    archive_path = dist / args.archive_name
+    with tarfile.open(archive_path, "w:gz") as archive:
+      archive.add(stage, arcname=stage.name)
+  else:
+    raise SystemExit(f"Unsupported archive extension: {args.archive_name}")
+
+  print(archive_path)
+
+
+def checksums(args: argparse.Namespace) -> None:
+  dist = args.dist.resolve()
+  archives = sorted(
+    path for path in dist.iterdir()
+    if path.is_file() and (path.name.endswith(".tar.gz") or path.name.endswith(".zip"))
+  )
+  if not archives:
+    raise SystemExit(f"No release archives found in {dist}")
+
+  lines: list[str] = []
+  for archive in archives:
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    lines.append(f"{digest}  {archive.name}")
+  args.output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+  print(args.output)
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser()
+  subcommands = parser.add_subparsers(dest="command", required=True)
+
+  metadata_parser = subcommands.add_parser("metadata")
+  metadata_parser.add_argument("--tag", required=True)
+  metadata_parser.add_argument("--source-dir", type=Path, default=Path.cwd())
+  metadata_parser.add_argument("--github-output", type=Path)
+  metadata_parser.set_defaults(func=metadata)
+
+  package_parser = subcommands.add_parser("package")
+  package_parser.add_argument("--stage", type=Path, required=True)
+  package_parser.add_argument("--dist", type=Path, required=True)
+  package_parser.add_argument("--archive-name", required=True)
+  package_parser.set_defaults(func=package)
+
+  checksums_parser = subcommands.add_parser("checksums")
+  checksums_parser.add_argument("--dist", type=Path, required=True)
+  checksums_parser.add_argument("--output", type=Path, required=True)
+  checksums_parser.set_defaults(func=checksums)
+
+  args = parser.parse_args()
+  args.func(args)
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## Summary

- add a tag-triggered GitHub-native release workflow for `vMAJOR.MINOR.PATCH` tags, with manual rehearsal support
- stage release installs through CMake, package Linux/macOS tarballs and Windows zip archives, and generate `SHA256SUMS`
- bump the project version to `0.3.0` and require release tags to match the CMake project version
- update README download guidance to GitHub Releases and add maintainer release documentation

## Validation

- `cmake --preset release -DVCPKG_TARGET_TRIPLET=arm64-osx`
- `cmake --build --preset release --parallel`
- `ctest --preset release --output-on-failure`
- `cmake --install build/release --prefix release-stage/abrade-0.3.0-macos-arm64`
- `python3 tools/release/release.py package --stage release-stage/abrade-0.3.0-macos-arm64 --dist dist --archive-name abrade-0.3.0-macos-arm64.tar.gz`
- `python3 tools/release/release.py checksums --dist dist --output dist/SHA256SUMS`
- `cmake --preset ci -DVCPKG_TARGET_TRIPLET=arm64-osx`
- `cmake --build --preset ci --parallel`
- `ctest --preset ci --output-on-failure`
- CLI smoke commands for `--help`, pattern `--test`, and stdin `--test`
- `actionlint`
- `python3 -m py_compile tools/release/release.py`
- `python3 tools/release/release.py metadata --tag v0.3.0 --source-dir .`

Refs #23
Closes #24
Closes #25
Closes #26
Closes #27
Refs #28
Refs #29
Refs #12
