### PR TITLE
ci: move required build back to github-hosted runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,86 +20,8 @@ env:
   VCPKG_COMMIT: 38a77589121bd7ec6487927b79c191a75d4ebdd6
 
 jobs:
-  build-marvin:
-    name: Build (Marvin)
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: [self-hosted, Linux, X64, marvin, abrade-temp]
-    timeout-minutes: 120
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Show runner context
-        run: |
-          echo "runner_name=${RUNNER_NAME}"
-          echo "runner_os=${RUNNER_OS}"
-          echo "runner_arch=${RUNNER_ARCH}"
-          uname -a
-          cmake --version
-          ninja --version
-          git --version
-
-      - name: Prepare vcpkg
-        shell: bash
-        run: |
-          set -euo pipefail
-          git clone --filter=blob:none https://github.com/microsoft/vcpkg.git "${RUNNER_TEMP}/vcpkg"
-          git -C "${RUNNER_TEMP}/vcpkg" checkout "${VCPKG_COMMIT}"
-          "${RUNNER_TEMP}/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
-          mkdir -p "${RUNNER_TEMP}/vcpkg-cache"
-          {
-            echo "VCPKG_ROOT=${RUNNER_TEMP}/vcpkg"
-            echo "VCPKG_BINARY_SOURCES=clear;files,${RUNNER_TEMP}/vcpkg-cache,readwrite"
-            echo "VCPKG_TARGET_TRIPLET=x64-linux"
-          } >> "${GITHUB_ENV}"
-
-      - name: Cache vcpkg binary packages
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/vcpkg-cache
-          key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('vcpkg.json') }}-${{ env.VCPKG_COMMIT }}
-          restore-keys: |
-            vcpkg-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Configure
-        shell: bash
-        run: cmake --preset ci -DVCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}"
-
-      - name: Build
-        run: cmake --build --preset ci --parallel
-
-      - name: Static analysis
-        shell: bash
-        run: |
-          set -euo pipefail
-          if command -v cppcheck >/dev/null 2>&1; then
-            cmake --build --preset ci --target abrade_cppcheck
-          else
-            echo "::notice::cppcheck is not installed on this runner; skipping optional static analysis"
-          fi
-
-      - name: Test
-        run: ctest --preset ci
-
-      - name: Smoke CLI
-        shell: bash
-        run: |
-          set -euo pipefail
-          ./build/ci/abrade --help
-          ./build/ci/abrade example.com '/items/{1:3}' --test
-          printf '/a\n/b\n' | ./build/ci/abrade example.com --stdin --test
-
-      - name: Upload abrade artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: abrade-linux-x64
-          path: build/ci/abrade
-          if-no-files-found: error
-
-  build-fork-pr:
-    name: Build (fork PR)
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+  build-github:
+    name: Build (GitHub)
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
@@ -110,7 +32,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake curl git ninja-build perl pkg-config tar unzip zip
+          sudo apt-get install -y build-essential cmake cppcheck curl git ninja-build perl pkg-config tar unzip zip
 
       - name: Prepare vcpkg
         shell: bash

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -22,8 +22,8 @@ Use the `Release` workflow manually before pushing a real release tag:
 5. Confirm the workflow produces `release-assets-TAG`.
 6. Download the artifact and verify `SHA256SUMS`.
 
-The rehearsal uses hosted Linux, macOS, and Windows runners. Ordinary PRs remain
-on the bounded Marvin/fork-safe CI path.
+The rehearsal uses hosted Linux, macOS, and Windows runners. Ordinary PRs use
+the hosted Ubuntu `Build (GitHub)` check.
 
 Before rehearsing, confirm the user-facing docs match the release:
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -40,7 +40,7 @@ The executable is written to `build/dev/abrade` on Unix-like hosts and
 ## CI-Equivalent Build
 
 Use the `ci` preset when you want the same release-mode build used by the
-required Marvin check:
+required hosted GitHub Actions check:
 
 ```sh
 cmake --preset ci
@@ -140,10 +140,9 @@ The canonical targets are:
 
 ## GitHub Actions
 
-The required protected check is named `Build (Marvin)`. It runs on the temporary
-Marvin self-hosted runner for trusted pushes and same-repository pull requests.
-Fork pull requests use the fork-safe hosted Ubuntu fallback. A manual hosted
-validation workflow matrix is available through `workflow_dispatch` for
-selective Ubuntu, macOS, and Windows validation.
+The required protected check is named `Build (GitHub)`. It runs on GitHub's
+hosted Ubuntu runner for pushes and pull requests. A manual hosted validation
+workflow matrix is available through `workflow_dispatch` for selective Ubuntu,
+macOS, and Windows validation.
 
 The release workflow is tag-driven and documented in [RELEASING.md](RELEASING.md).


### PR DESCRIPTION
## Summary
- replace the temporary Marvin self-hosted required CI job with a GitHub-hosted Ubuntu job named `Build (GitHub)`
- remove the separate fork PR fallback because the hosted required job is fork-safe by default
- update build and release docs to stop referencing Marvin as the routine CI path

## Validation
- `actionlint`
- `git diff --check`
- stale-reference scan for Marvin/self-hosted runner labels in workflow/docs

## Follow-up After This Check Exists
- update `master` branch protection required status checks from `Build (Marvin)` to `Build (GitHub)`
- merge after `Build (GitHub)` passes
- verify post-merge `Build (GitHub)` on `master`
- purge the repo-scoped `marvin-abrade-temp-1` runner via Marvin Ops
